### PR TITLE
convert: stop gawk v5 warning

### DIFF
--- a/applications/convert/convertawk
+++ b/applications/convert/convertawk
@@ -1,5 +1,5 @@
 BEGIN {out=0}
-/^\!/  {if(out==0)
+/^!/  {if(out==0)
           {out=1
            print ""
            print "!! ** Error converting", fmt


### PR DESCRIPTION
convert: stop warning about protected non-special character in gawk version 5 (fedora 31).
Reported by John Lucey.

Fixed #66.

Please accept when happy, branch can be removed.