### PR TITLE
KAPPA: Devise a means of plotting DISPLAY's key aligned with the DATA…

### DIFF
--- a/applications/kappa/component.xml
+++ b/applications/kappa/component.xml
@@ -3,7 +3,7 @@
 <!-- component.xml.  Generated from component.xml.in by configure. -->
 
 <component id="kappa" support="S">
-  <version>2.6-7</version>
+  <version>2.6-8</version>
   <path>applications/kappa</path>
   <description>KAPPA - Kernel Application Package</description>
   <abstract><p>

--- a/applications/kappa/configure.ac
+++ b/applications/kappa/configure.ac
@@ -2,7 +2,7 @@ dnl    Process this file with autoconf to produce a configure script
 AC_REVISION($Revision$)
 
 dnl    Initialisation: package name and version number
-AC_INIT(kappa, 2.6-7, starlink@jiscmail.ac.uk)
+AC_INIT(kappa, 2.6-8, starlink@jiscmail.ac.uk)
 AC_CONFIG_AUX_DIR([build-aux])
 
 dnl    Require autoconf-2.50 at least

--- a/applications/kappa/kappa.news.in
+++ b/applications/kappa/kappa.news.in
@@ -26,6 +26,14 @@
       new parameters called MODE and FILE.  The default for MODE
       preserves the historic interactive behaviour.
 
+   o  DISPLAY
+
+      -  Parameter KEYPOS(2) accepts negative values to instruct
+      DISPLAY to plot the key aligned with the image.  Thus setting
+      KEY=TRUE and KEYPOS=[0,-1] will draw the colour-table ramp so
+      that it  abuts the image with its vertical extent matching the
+      image, as commonly needed for journal graphics.
+
    o  LINPLOT
 
       -  The XMAP parameter now has a new option called "LRLinear",

--- a/applications/kappa/sun95.tex
+++ b/applications/kappa/sun95.tex
@@ -6,9 +6,9 @@
 \stardocsource    {sun95.44}
 \stardocnumber    {95.44}
 \stardocauthors   {Malcolm J. Currie \& David S. Berry}
-\stardocdate      {2020 April 24}
+\stardocdate      {2020 August 1}
 \stardoctitle     {KAPPA --- Kernel Application Package}
-\stardocversion   {2.6-7}
+\stardocversion   {2.6-8}
 \stardocmanual    {User's Guide}
 % -----------------------------------------------------------------------------
 \stardocabstract{
@@ -18417,14 +18417,20 @@ KAPPA: \htmlref{LISTSHOW}{LISTSHOW},
       \sstsubsection{
          KEYPOS( 2 ) = \_REAL (Read)
       }{
-        The first element gives the gap between the right-hand edge of
-        the display and the left-hand edge of the key, as a fraction
-        of the width of the current picture.  If a key is produced,
-        then the right-hand margin specified by Parameter MARGIN is
-        ignored, and the value supplied for KEYPOS is used instead.
-        The second element gives the vertical position of the key as a
-        fractional value in the range zero to one: zero puts the key as
-        low as possible, one puts it as high as possible. \texttt{[}current value\texttt{{]}}
+         The first element gives the gap between the right-hand edge of
+         the display and the left-hand edge of the key, as a fraction
+         of the width of the current picture.  If a key is produced,
+         then the right-hand margin specified by Parameter MARGIN is
+         ignored, and the value supplied for KEYPOS is used instead.
+
+         The second element gives the vertical position of the key as a
+         fractional value in the range zero to one: zero puts the key
+         as low as possible, one puts it as high as possible.  A
+         negative value (no lower than \texttt{-1}) causes the key to
+         match the height of the display image. This may mean any text,
+         like a label, for the horizontal axis may not appear, though
+         if AXES is \texttt{TRUE} there is usually room.
+         \texttt{[}current value\texttt{{]}}
       }
       \sstsubsection{
          KEYSTYLE = \htmlref{GROUP}{se:groups} (Read)
@@ -18791,6 +18797,15 @@ KAPPA: \htmlref{LISTSHOW}{LISTSHOW},
          stored in an NDF called video.
       }
       \sstexamplesubsection{
+         display kn26 axes key keypos=[0.0,-1.0] keystyle=$\wedge$key.sty $\backslash$
+      }{
+         Displays the NDF called kn26 using the current scaling,
+         surrounded by axes.  It adds a colour-table key to the right
+         that abuts the data picture and is aligned vertically with
+         the image.  The plot attributes set in the text file \texttt{key.sty}
+         controls the appearance of the key.
+      }
+      \sstexamplesubsection{
          display video noscale $\backslash$
       }{
          Displays the DATA component of the NDF called video (created
@@ -18850,14 +18865,16 @@ KAPPA: \htmlref{LISTSHOW}{LISTSHOW},
          \sstitem
          The application stores a number of pictures in the graphics
          database in the following order: a FRAME picture containing the
-         annotated axes, the image area, and the border; a DATA picture
-         containing just the image area.  Note, the FRAME picture is only
-         created if annotated axes or a border have been drawn, or if non-zero
-         margins were specified using Parameter MARGIN.  The world co-ordinates
-         in the DATA picture will be pixel co-ordinates.  A reference to the
-         supplied NDF, together with a copy of the \htmlref{WCS}{apndf:wcs} information in the NDF
-         are stored in the DATA picture.  On exit the current database picture
-         for the chosen device reverts to the input picture.
+         annotated axes, the image area, and the border; if there is a key,
+         a KEY picture encompassing the key and its annotations; and a DATA
+         picture containing just the image area.  Note, the FRAME picture
+         is only created if annotated axes or a border have been drawn, or
+         if non-zero margins were specified using Parameter MARGIN.  The
+         world co-ordinates in the DATA picture will be pixel co-ordinates.
+         A reference to the supplied NDF, together with a copy of the \htmlref{WCS}{apndf:wcs}
+         information in the NDF are stored in the DATA picture.  On exit
+         the current database picture for the chosen device reverts to the
+         input picture.
 
          \sstitem
          The data type of the output NDF depends on the number of colour
@@ -18876,7 +18893,8 @@ KAPPA: \htmlref{LISTSHOW}{LISTSHOW},
       Related Applications
    }{
 KAPPA: \htmlref{WCSFRAME}{WCSFRAME},
-\htmlref{PICDEF}{PICDEF};
+\htmlref{PICDEF}{PICDEF},
+\htmlref{LUTVIEW}{LUTVIEW};
 \xref{FIGARO}{sun86}{}: \xref{IGREY}{sun86}{IGREY},
 \xref{IMAGE}{sun86}{IMAGE},
 \xref{MOVIE}{sun86}{MOVIE}.
@@ -54278,6 +54296,15 @@ The following applications have been modified:
         NDF sections and fill values in a text file.   This is made
         possible new parameters called MODE and FILE.  The default
         for MODE preserves the historic interactive behaviour.
+      \end{itemize}
+
+   \item [\htmlref{DISPLAY}{DISPLAY}]\mbox{}
+      \begin{itemize}
+        \item Parameter KEYPOS(2) accepts negative values to instruct DISPLAY
+        to plot the key aligned with the image.  Thus setting KEY=\texttt{TRUE}
+        and KEYPOS=\texttt{[0,-1]} will draw the colour-table ramp so that it
+        abuts the image with its vertical extent matching the image,
+        as commonly needed for journal graphics.
       \end{itemize}
 
    \item [\htmlref{LINPLOT}{LINPLOT}]\mbox{}

--- a/libraries/kaplibs/kpg/kpg1_asshr.f
+++ b/libraries/kaplibs/kpg/kpg1_asshr.f
@@ -19,9 +19,10 @@
 *     This routine creates a new Plot covering the same window as the
 *     current PGPLOT window, but the window is shrunk in GRAPHICS space
 *     so that all the annotation produced by AST_GRID falls within the PGPLOT
-*     viewport which is current on entry. The sizes of annotations, gaps,
-*     etc. are shrunk if this is necessary in order to fit the annotations
-*     within the current PGPLOT viewport.
+*     viewport that is current on entry. (However, see Argument RJUST
+*     for a way to prevent shrinkage along an axis.)  The sizes of
+*     annotations, gaps, etc. are shrunk if this is necessary in order
+*     to fit the annotations within the current PGPLOT viewport.
 
 *  Arguments:
 *     ASP = LOGICAL (Given)
@@ -56,12 +57,14 @@
 *        used instead. Other unrecognised values are treated as "C".
 *     RJUST( 2 ) = REAL (Given)
 *        Each element is used only if the corresponding element in JUST
-*        is a apce. The first element gives the fractional vertical position
+*        is a space. The first element gives the fractional vertical position
 *        of the new plot: 0.0 means put the new plot as low as possible, 1.0
 *        means put it as high as possible. The second element gives the
 *        fractional horizontal position of the new plot: 0.0 means put the
 *        new plot as far to the left as possible, 1.0 means put it as far
-*        to the right as possible.
+*        to the right as possible.  A negative value requests that no
+*        space be allocated for annotations, tick marks, gaps etc. along
+*        the respective axis.
 *     IPLOT = INTEGER (Given and Returned)
 *        The Plot. The supplied Plot is annulled and a new one is
 *        returned in its place. The new Plot contains all the Frames of
@@ -76,6 +79,8 @@
 
 *  Copyright:
 *     Copyright (C) 1999 Central Laboratory of the Research Councils.
+*     Copyright (C) 2016, East Asian Observatory.
+*     Copyright (C) 2020 Science & Technology Facilities Council.
 *     All Rights Reserved.
 
 *  Licence:
@@ -96,6 +101,7 @@
 
 *  Authors:
 *     DSB: David S. Berry (STARLINK)
+*     MJC: Malcolm J. Currie (STARLINK)
 *     {enter_new_authors_here}
 
 *  History:
@@ -103,7 +109,11 @@
 *        Original version.
 *     6-DEC-2016 (DSB):
 *        Added argument RJUST.
-*     {enter_changes_here}
+*     2020 July 30 (MJC):
+*        Negative RJUST values make the Plot fill the current viewport
+*        along the respective axis, i.e. ignore creating room for
+*        annotations, tick marks, and gaps.
+*     {enter_further_changes_here}
 
 *  Bugs:
 *     {note_any_bugs_here}
@@ -586,6 +596,16 @@
          END DO
 
       END DO
+
+      IF ( JUST( 1:1 ) .EQ. ' ' .AND. RJUST( 1 ) .LT. 0.0 ) THEN
+         GBOX( 2 ) = TBOX( 2 )
+         GBOX( 4 ) = TBOX( 4 )
+      END IF
+
+      IF ( JUST( 2:2 ) .EQ. ' ' .AND. RJUST( 2 ) .LT. 0.0 ) THEN
+         GBOX( 1 ) = TBOX( 1 )
+         GBOX( 3 ) = TBOX( 3 )
+      END IF
 
 *  Check that the plotting area found above has significant width and height
 *  (more than 2mm).

--- a/libraries/kaplibs/kpg/kpg1_gdnew.f
+++ b/libraries/kaplibs/kpg/kpg1_gdnew.f
@@ -59,7 +59,7 @@
 *     PNAME( NP ) = CHARACTER * ( * ) (Given)
 *        The names to store in the AGI database with the NP extra pictures.
 *     PSIDE( NP ) = CHARACTER * 1 (Given)
-*        Each element of this array should be one of L, R, T or B. It
+*        Each element of this array should be one of L, R, T, B, or D. It
 *        indicates which side of the FRAME picture an extra picture is to be
 *        placed. For Left and Right, the extra picture occupies the full
 *        height of the DATA picture, margins, and any previously created
@@ -67,7 +67,10 @@
 *        all previously created pictures. For Top or Bottom, the extra picture
 *        occupies the full width of the DATA picture, margins, and any
 *        previously created extra pictures. The picture is placed at the top or
-*        bottom of all previously created pictures. Ignored if NP is zero.
+*        bottom of all previously created pictures.  D is a variant of
+*        R, where the plot is to the right, but the vertical extent is
+*        that of the DATA picture instead of the FRAME picture. This
+*        argument is ignored if NP is zero.
 *     PSIZE( NP ) = REAL (Given)
 *        The size of each extra picture. For Left and Right pictures, this
 *        is the width of the picture, and the value is given as a fraction
@@ -114,6 +117,7 @@
 
 *  Copyright:
 *     Copyright (C) 1998, 1999, 2000 Central Laboratory of the Research Councils.
+*     Copyright (C) 2006, 2020 Science & Technology Facilities Council.
 *     All Rights Reserved.
 
 *  Licence:
@@ -134,6 +138,7 @@
 
 *  Authors:
 *     DSB: David S. Berry (STARLINK)
+*     MJC: Malcolm J. Currie (STARLINK)
 *     {enter_new_authors_here}
 
 *  History:
@@ -145,8 +150,10 @@
 *     10-AUG-2000 (DSB):
 *        Modified to allow negative margins.
 *     23-AUG-2006 (DSB):
-*        When checking foir zero-sized boxes, include effects of truncation
+*        When checking for zero-sized boxes, include effects of truncation
 *        from double to single precision.
+*     2020 July 30 (MJC):
+*        Introduced D option in PSIDE.
 *     {enter_changes_here}
 
 *  Bugs:
@@ -281,7 +288,7 @@
 
          IF( PSIDE( I ) .EQ. 'L' ) THEN
             FXL = MIN( FXR, FXL + ABS( PSIZE( I )*CXI ) )
-         ELSE IF( PSIDE( I ) .EQ. 'R' ) THEN
+         ELSE IF( PSIDE( I ) .EQ. 'R' .OR. PSIDE( I ) .EQ. 'D' ) THEN
             FXR = MAX( FXL, FXR - ABS( PSIZE( I )*CXI ) )
          ELSE IF( PSIDE( I ) .EQ. 'T' ) THEN
             FYT = MAX( FYB, FYT - ABS( PSIZE( I )*CYI ) )
@@ -373,7 +380,7 @@
 
          IF( PSIDE( I ) .EQ. 'L' ) THEN
             SXL = SXL - ABS( PSIZE( I )*CXI )
-         ELSE IF( PSIDE( I ) .EQ. 'R' ) THEN
+         ELSE IF( PSIDE( I ) .EQ. 'R' .OR. PSIDE( I ) .EQ. 'D' ) THEN
             SXR = SXR + ABS( PSIZE( I )*CXI )
          ELSE IF( PSIDE( I ) .EQ. 'T' ) THEN
             SYT = SYT + ABS( PSIZE( I )*CYI )
@@ -470,6 +477,14 @@
             PXR = SXR
             PYB = SYB
             PYT = SYT
+
+            SXR = PXL
+
+         ELSE IF( PSIDE( I ) .EQ. 'D' ) THEN
+            PXL = MAX( SXL, SXR - ABS( PSIZE( I )*CXI ) )
+            PXR = SXR
+            PYB = DYB
+            PYT = DYT
 
             SXR = PXL
 

--- a/libraries/kaplibs/kpg/kpg1_gdold.f
+++ b/libraries/kaplibs/kpg/kpg1_gdold.f
@@ -48,7 +48,7 @@
 *     PNAME( NP ) = CHARACTER * ( * ) (Given)
 *        The names to store in the AGI database with the NP extra pictures.
 *     PSIDE( NP ) = CHARACTER * 1 (Given)
-*        Each element of this array should be one of L, R, T or B. It
+*        Each element of this array should be one of L, R, T, B, or D. It
 *        indicates which side of the FRAME picture an extra picture is to be
 *        placed. For Left and Right, the extra picture occupies the full
 *        height of the DATA picture, margins, and any previously created
@@ -56,7 +56,10 @@
 *        all previously created pictures. For Top or Bottom, the extra picture
 *        occupies the full width of the DATA picture, margins, and any
 *        previously created extra pictures. The picture is placed at the top or
-*        bottom of all previously created pictures. Ignored if NP is zero.
+*        bottom of all previously created pictures.  D is a variant of
+*        R, where the plot is to the right, but the vertical extent is
+*        that of the DATA picture instead of the FRAME picture. This
+*        argument is ignored if NP is zero.
 *     PSIZE( NP ) = REAL (Given)
 *        The size of each extra picture. For Left and Right pictures, this is
 *        the width of the picture, and the value is given as a fraction of
@@ -90,6 +93,7 @@
 
 *  Copyright:
 *     Copyright (C) 1998, 1999, 2000, 2001 Central Laboratory of the Research Councils.
+*     Copyright (C) 2020 Science & Technology Facilities Council.
 *     All Rights Reserved.
 
 *  Licence:
@@ -110,6 +114,7 @@
 
 *  Authors:
 *     DSB: David S. Berry (STARLINK)
+*     MJC: Malcolm J. Currie (STARLINK)
 *     {enter_new_authors_here}
 
 *  History:
@@ -123,6 +128,8 @@
 *     9-JAN-2001 (DSB):
 *        Clip ancillary pictures so that they are contained within the Frame
 *        picture, not the original current picture.
+*     2020 July 30 (MJC):
+*        Introduced D option in PSIDE.
 *     {enter_changes_here}
 
 *  Bugs:
@@ -251,6 +258,12 @@
             PYB = SYB
             PYT = SYT
 
+         ELSE IF ( PSIDE( I ) .EQ. 'D' ) THEN
+            PXL = SXR
+            PXR = SXR + ABS( PSIZE( I )*CXI )
+            PYB = DYB
+            PYT = DYT
+
          ELSE IF( PSIDE( I ) .EQ. 'L' ) THEN
             PXL = SXL - ABS( PSIZE( I )*CXI )
             PXR = SXL
@@ -354,6 +367,12 @@
             PXR = SXR + ABS( PSIZE( I )*CXI )
             PYB = SYB
             PYT = SYT
+
+         ELSE IF ( PSIDE( I ) .EQ. 'D' ) THEN
+            PXL = SXR
+            PXR = SXR + ABS( PSIZE( I )*CXI )
+            PYB = DYB
+            PYT = DYT
 
          ELSE IF( PSIDE( I ) .EQ. 'L' ) THEN
             PXL = SXL - ABS( PSIZE( I )*CXI )


### PR DESCRIPTION
… picture.

It seems to be a common requirement in journals for image graphics to
include an intensity key besides each image, and this key has most
commonly the height of the image.  It gives the best resolution of the
colour ramp and looks neat.

Trying to achieve this in KAPPA adjusting various parameters proved
fruitless, in the main because of KAPLIBS subroutine KPG1_ASSHR that
allocates plenty of room for annotations and typically leading to a
key that is only circa two thirds of the height of the image.  So I've
hacked the code without changing any APIs to make this possible.

There were two main steps:
a) adjust the KEY picture height so that it matches the DATA picture
vertical bounds; and

b) let the vertical placement value be negative (the PAR_GDR1R call
already allowed this), and recognise a such a negative value as a
request not to reduced the key vertical plotting area for annotations,
gaps, tick marks etc..

Specifically, for a) I introduced a position code of D (for Data) for
the key placement, and for b) I used negative KEYPOS(2)->RJUST(1) in a
test near the end of KPG1_ASSHR to assign GBOX(2/4) to TBOX(2/4).  Yes
some of the intervening calculations in the latter are superfluous for
this special case, but I didn't want to hack with lots of IF clauses
or mess anything up for normal operation.

To give this option more visibility I added an example in DISPLAY.
If approved, then we should add a item with an example graphic in the
JCMT Software Blog.

I also fixed a bug in display.f, where only one KEYPOS
value was being passed to a two-element RJUST in KPG1_LUTKY.